### PR TITLE
Dijkstra's wastes memory and time queuing nodes already in the queue

### DIFF
--- a/src/crow/ConnectedNode.js
+++ b/src/crow/ConnectedNode.js
@@ -16,7 +16,7 @@ crow.ConnectedNode.prototype.connectTo = function(otherNode, distance, symmetric
 	if(typeof distance == "undefined") distance = 1;
 	this.connections.push(otherNode);
 	this.connectionDistances[otherNode.id] = distance;
-	if(typeof symmetric !== "false" && otherNode instanceof crow.ConnectedNode){
+	if(symmetric !== false && otherNode instanceof crow.ConnectedNode){
 		otherNode.connections.push(this);
 		otherNode.connectionDistances[this.id] = distance;
 	}

--- a/src/crow/Graph.js
+++ b/src/crow/Graph.js
@@ -61,6 +61,26 @@ crow.Graph = function(){
 			delete this.map[x.id];
 		}
 	};
+	//Replace the node that was at x, y with the givenNode
+	// O(n) where n is the number of nodes
+	/**
+	 * Replaces a node on the graph
+	 * @param {crow.BaseNode} node Node to replace existing node at the same position or id.
+	 * @param {boolean} [alsoInvalidate=false] Whether to also invalidate the position of the replaced node.
+	 */
+	this.replaceNode = function(node, alsoInvalidate){
+		node._initialize();
+		var oldNode = this.map[node.id];
+		this.map[node.id] = node;
+		for(var i = 0; i < this.nodes.length; i++){
+			if(this.nodes[i] === oldNode){
+				this.nodes[i] = node;
+			}
+		}
+		if(!(node.x === undefined)){
+			this.invalidate(node.x,node.y);
+		}
+	};
 	/**
 	 * <p>Gets a node at a particular coordinate, or the first node that meets a condition
 	 * <p>O(1) if a coordinate is given

--- a/src/crow/algorithm/DijkstraAlgorithm.js
+++ b/src/crow/algorithm/DijkstraAlgorithm.js
@@ -110,7 +110,15 @@ crow.algorithm.DijkstraAlgorithm.prototype.mainLoop = function(node, endNode){
 				currentNeighborDistance = neighborDistanceThroughMe;
 			}
 			if(currentNeighborDistance < Infinity){
-				nextNodes.enqueue(currentNeighborDistance, neighbor);
+				var existing = nextNodes.getPriority(neighbor);
+				if(existing !== null) {
+					if(currentNeighborDistance < existing) {
+						nextNodes.remove(neighbor);
+						nextNodes.enqueue(currentNeighborDistance, neighbor);
+					}
+				} else {
+					nextNodes.enqueue(currentNeighborDistance, neighbor);
+				}
 			}
 		}
 		node.visited = true;


### PR DESCRIPTION
It also causes problems when using a function to filter and gather info as nodes are in the visited list more than once. If a node is already in the queue it should look to see which path is shorter and select it.

I'm not positive that this is the best place for the fix, possibly it would be cleaner to apply it to the queue itself.
