### PR TITLE
Created the ArrayUtilities class for shuffle, indexOf was kept the way it is.

### DIFF
--- a/src/crow/algorithm/BasicTraversalAlgorithm.js
+++ b/src/crow/algorithm/BasicTraversalAlgorithm.js
@@ -40,7 +40,7 @@ crow.algorithm.BasicTraversalAlgorithm.prototype.findPath = function(start, goal
 		
 		var neighbors = el.innerNode.getNeighbors(this.graph);
 		if(opts.random){
-			neighbors = neighbors.shuffle();
+			neighbors = ArrayUtilities.shuffle(neighbors);
 		}
 		for(var i = 0; i < neighbors.length; i++){
 			var neighbor = this._getWrapperNode(neighbors[i]);

--- a/src/crow/util/MonkeyPatches.js
+++ b/src/crow/util/MonkeyPatches.js
@@ -1,5 +1,26 @@
 goog.provide('crow.util.MonkeyPatches');
 
+var ArrayUtilities = {
+    
+    /*!
+     * + Jonas Raoni Soares Silva
+     * //@ http://jsfromhell.com/array/shuffle [rev. #1]
+     * Altered so that doesn't modify Array.prototype
+     */
+    shuffle: function(array) {
+        /* the following if statement runs basically isArray(array)
+         * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray
+         * I don't want to add further functions to the Array.prototype
+         */
+        if(Object.prototype.toString.call(array) === '[object Array]') {
+            var v = array.concat();
+            for(var j, x, i = v.length; i; j = parseInt(Math.random() * i), x = v[--i], v[i] = v[j], v[j] = x){}
+            return v;
+        }
+    }
+}
+
+
 /**
  * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/indexOf#Compatibility
  */
@@ -23,17 +44,5 @@ if (!Array.prototype.indexOf)
         return from;
     }
     return -1;
-  };
-}
-
-/*!
- * + Jonas Raoni Soares Silva
- * //@ http://jsfromhell.com/array/shuffle [rev. #1]
- */
-if(!Array.prototype.shuffle){
-	Array.prototype.shuffle = function(){
-		var v = this.concat();
-    for(var j, x, i = v.length; i; j = parseInt(Math.random() * i), x = v[--i], v[i] = v[j], v[j] = x){}
-    return v;
   };
 }


### PR DESCRIPTION
To avoid modifying Array.prototype to have the shuffle function, I did this modifications, creating an ArrayUtilities object.

All the occurrences of shuffle() have been patched (1). since indexOf is standard for ECMAscript5, we should decide whether we want to move also indexOf into the ArrayUtilities for backwards-compatibility.

I don't yet know how do you test this library and if you have specified test stages or protocols, so please note that this was not tested yet.

Array.indexOf is already there for recent versions of all the browsers, but older ones will take the specified prototype here, and then the issue of extending Array.prototype would pop again. So we have to decide whether this approach is ok to be used for indexOf as well.
